### PR TITLE
Fixes `max`, `min`, `prod` & `sum` for keyed tables

### DIFF
--- a/src/pykx/pandas_api/pandas_meta.py
+++ b/src/pykx/pandas_api/pandas_meta.py
@@ -51,8 +51,8 @@ def _get_bool_only_subtable(tab):
 
 def preparse_computations(tab, axis=0, skipna=True, numeric_only=False, bool_only=False):
     if 'Keyed' in str(type(tab)):
-        tab = q('{(keys x) _ 0!x}', tab)
-    cols = q('cols', tab)
+        tab = tab.values()
+    cols = tab.columns
     if numeric_only:
         (tab, cols) = _get_numeric_only_subtable_with_bools(tab)
     if bool_only:

--- a/tests/test_pandas_api.py
+++ b/tests/test_pandas_api.py
@@ -1810,7 +1810,7 @@ def test_pandas_max(q):
     for i in range(100):
         assert float(qmax[i]) == float(pmax[i])
 
-    ktab = q('{1!x}', tab)
+    ktab = tab.set_index('sym')
     df = ktab.pd()
 
     qmax = ktab.max().py()


### PR DESCRIPTION
# Bug Fix

- Please insert link to github issue here: https://github.com/KxSystems/pykx/issues/18

## What is the bug?

If possible please include a summary and reproducible use-case below:
Several functions from the Pandas API raise a `length` error while working over the default axis.
```python
>>> import pykx as kx
>>> t = kx.q('([a:1 2]b:3 4;c:5 6)')
>>> t
pykx.KeyedTable(pykx.q('
a| b c
-| ---
1| 3 5
2| 4 6
'))
>>> t.max()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/j/Github/hablapps/pykx/pykx-dev/lib/python3.9/site-packages/pykx/pandas_api/__init__.py", line 57, in return_va
l
    res = func(*args, **kwargs)
  File "/Users/j/Github/hablapps/pykx/pykx-dev/lib/python3.9/site-packages/pykx/pandas_api/pandas_meta.py", line 80, in inner
    return q('{[x; y] y!x}', res, cols)
  File "/Users/j/Github/hablapps/pykx/pykx-dev/lib/python3.9/site-packages/pykx/embedded_q.py", line 226, in __call__
    return factory(result, False)
  File "pykx/_wrappers.pyx", line 507, in pykx._wrappers._factory
  File "pykx/_wrappers.pyx", line 500, in pykx._wrappers.factory
pykx.exceptions.QError: length
```

## How does the change fix it?

I think that the simplest fix is to reorder the calculation of the `cols` variable at the `preparse_computations` general method. By doing so, we get rid of the redundant keys and the result is consistent with `@convert_result`. This simple change fixes all `max`, `min`, `prod` and `sum` (and also `any` and `all`) when invoked with a keyed table and default axis.

## Code

- [x] Is code production ready (no stub/test functions, hardcoded IP/ tables/ hostnames, etc.)?

## Testing

- [x] Have unit tests been created or existing ones updated to catch this bug in the future?
- [x] Has test coverage remained the same or improved?
