### PR TITLE
Fixed typo

### DIFF
--- a/docs/api/pykx-execution/q.md
+++ b/docs/api/pykx-execution/q.md
@@ -2821,7 +2821,7 @@ See https://code.kx.com/q/ref/tok/ for more information on accepted lists for ca
 >>> kx.q.tok(b'F', b'3.14')
 pykx.FloatAtom(pykx.q('3.14'))
 >>> float_int = kx.toq(-9, kx.ShortAtom)
->>> kx.qkx.toq(int(1), kx.ShortAtom)
+>>> kx.toq(int(1), kx.ShortAtom)
 ```
 
 ### [compose](https://code.kx.com/q/ref/compose/)


### PR DESCRIPTION
# Documentation template

## What does this change introduce? 

The expression  `kx.qkx.toq(int(1), kx.ShortAtom)` doesn't work. It's been replaced by  `kx.toq(int(1), kx.ShortAtom)`

## Checklist

- [X] Have you ensured that any changes to the documentation are correctly formatted, in particular are code snippets being correctly displayed?
- [X] If a new class has been added has a documentation stub `.md` file associated with it been created?
- [X] Have you ensured that any included hyperlinks are operating correctly?
- [X] If any documentation page has been created has it been added to `mkdocs.yml`
- [X] Have you checked your changes with a spell checker? (US English)
